### PR TITLE
Improve and fix Docker setup for local developmentirectories not writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use php:8.0-cli as base image
-FROM php:8.0-cli
+FROM php:8.1-cli
 
 # Author label (optional)
 LABEL authors="Paul C. Gaida"

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,11 @@ RUN composer install --ignore-platform-reqs --no-interaction
 # Copy project files
 COPY . .
 
+# Berechtigungen für das img-Verzeichnis setzen
+RUN mkdir -p /var/www/html/img && \
+    chown -R www-data:www-data /var/www/html/img && \
+    chmod -R 775 /var/www/html/img
+
 # Expose XDebug port
 EXPOSE 9003
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: osiris
     volumes:
       - .:/var/www/html
+      - ./img:/var/www/html/img:rw
+
     ports:
       - "8080:80"
     depends_on:

--- a/php/Settings.php
+++ b/php/Settings.php
@@ -3,6 +3,9 @@
 require_once "DB.php";
 include_once "Groups.php";
 
+/**
+ * Represents the application settings, including user roles, features, and activities.
+ */
 class Settings
 {
     /**
@@ -94,7 +97,7 @@ class Settings
 
     function printProfilePicture($user, $class = "", $embed = false)
     {
-        $root = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['HTTP_HOST'] . ROOTPATH;
+        $root = $this->getRequestScheme() . "://" . $_SERVER['HTTP_HOST'] . ROOTPATH;
         $default = '<img src="' . $root . '/img/no-photo.png" alt="Profilbild" class="' . $class . '">';
 
         if (empty($user)) return $default;
@@ -120,6 +123,26 @@ class Settings
             $img = "$root/img/users/$user.jpg?v=$v";
             return ' <img src="' . $img . '" alt="Profilbild" class="' . $class . '">';
         }
+    }
+
+
+    /**
+     * Determines the request scheme (http or https) based on server variables.
+     *
+     * @return string The request scheme ('http' or 'https').
+     */
+    public function getRequestScheme(): string
+    {
+        if (!empty($_SERVER['REQUEST_SCHEME'])) {
+            return $_SERVER['REQUEST_SCHEME'];
+        }
+
+        if ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ||
+            (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] === 443)) {
+            return 'https';
+        }
+
+        return 'http';
     }
 
     /**

--- a/routes/rest.php
+++ b/routes/rest.php
@@ -822,7 +822,7 @@ Route::get('/portfolio/project/([^/]*)', function ($id) {
     ];
 
     if (isset($result['public_image']) && !empty($result['public_image']))
-        $project['img'] = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . ROOTPATH . '/uploads/' . $result['public_image'];
+        $project['img'] = $Settings->getRequestScheme() . '://' . $_SERVER['HTTP_HOST'] . ROOTPATH . '/uploads/' . $result['public_image'];
 
     $project['activities'] = $osiris->activities->count(['projects' => $id, 'hide' => ['$ne' => true]]);
 
@@ -1334,7 +1334,7 @@ Route::get('/portfolio/person-images', function () {
             if (!file_exists(BASEPATH . "/img/users/$user.jpg")) {
                 continue;
             } else {
-                $img = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . ROOTPATH . "/img/users/$user.jpg";
+                $img = $Settings->getRequestScheme() . '://' . $_SERVER['HTTP_HOST'] . ROOTPATH . "/img/users/$user.jpg";
             }
         }
 
@@ -1356,7 +1356,7 @@ Route::get('/portfolio/person-images', function () {
 //         if (!file_exists(BASEPATH . "/img/users/$user.jpg")) {
 //             return null;
 //         } else {
-//             $img = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . ROOTPATH . "/img/users/$user.jpg";
+//             $img = $Settings->getRequestScheme() . '://' . $_SERVER['HTTP_HOST'] . ROOTPATH . "/img/users/$user.jpg";
 //         }
 //     }
 //     return $img;


### PR DESCRIPTION
### Description

This pull request includes several changes aimed at enhancing and fixing some issues with the application's Docker setup for local development:

1. **Refactor request scheme retrieval**:  
   Introduced a `getRequestScheme` method to replace direct access to `$_SERVER['REQUEST_SCHEME']`, ensuring better encapsulation and reliability. This resolves issues with the PHP development server not populating the variable.

2. **Set up permissions and volume for `/img` directory**:  
   - Updated the Dockerfile to create and set proper permissions for the `/img` directory, making it writable by the web server.  
   - Added a volume mount in `docker-compose.yml` to map the local `./img` directory, allowing support for file uploads.

3. **Update to PHP 8.1**:  
   The base image in the Dockerfile has been upgraded to PHP 8.1 to utilize the latest features and ensure continued compatibility with mongodb.
