### PR TITLE
Fix issue with sending e-mails without SMTP authentification

### DIFF
--- a/php/MailSender.php
+++ b/php/MailSender.php
@@ -18,11 +18,14 @@ function sendMail(
     if (!empty($mail['smtp_server'])) {
         $Mailer->isSMTP();
         $Mailer->Host = $mail['smtp_server'] ?? 'localhost';
-        if (isset($mail['smtp_user']) && isset($mail['smtp_password'])) {
+        if (isset($mail['smtp_user']) && isset($mail['smtp_password'])) {     
             $Mailer->SMTPAuth = true;
             $Mailer->Username = $mail['smtp_user'];
             $Mailer->Password = $mail['smtp_password'];
+        } else {
+            $Mailer->SMTPAuth = false;
         }
+        
         if (isset($mail['smtp_security'])) {
             if ($mail['smtp_security'] == 'ssl')
                 $Mailer->SMTPSecure = PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_SMTPS;


### PR DESCRIPTION
Explicitly set `SMTPAuth = false` if the SMTP server does not require user and password for authentification.