### PR TITLE
Fix: inline SVG via raw read instead of include (avoid short_open_tag parse errors)

### DIFF
--- a/php/_achievements.php
+++ b/php/_achievements.php
@@ -273,7 +273,7 @@ class Achievement
 
             <span class="thumb-sm" data-toggle="tooltip" data-title="<?= $title ?>">
                 <?php
-                include BASEPATH . "/img/achievements/ac_$ac[icon].svg";
+                echo file_get_contents(BASEPATH . "/img/achievements/ac_{$ac['icon']}.svg");
                 ?>
             </span>
 
@@ -342,7 +342,7 @@ class Achievement
             <div class="row">
                 <div class="col flex-grow-0 thumb">
                     <?php
-                    include BASEPATH . "/img/achievements/ac_$ac[icon].svg";
+                    echo file_get_contents(BASEPATH . "/img/achievements/ac_{$ac['icon']}.svg");
                     ?>
                 </div>
                 <div class="col">
@@ -387,3 +387,4 @@ class Achievement
         $this->osiris->achieved->insertMany($values);
     }
 }
+


### PR DESCRIPTION
Problem:
Including SVG files (e.g., img/achievements/*.svg) via `include` causes a PHP parse error when `short_open_tag=On`, because `<?xml version="1.0"?>` is interpreted as PHP open tag.

Fix:
Output SVGs raw (`file_get_contents`) instead of parsing them. This removes the implicit dependency on `short_open_tag=Off`. No behavior change besides eliminating the parse error.

Tests:
- With short_open_tag=On and Off, Achievements page renders SVGs inline without errors.