### PR TITLE
Remove misleading "windows" word from password placeholder

### DIFF
--- a/addons/ida/pages/ida-login.php
+++ b/addons/ida/pages/ida-login.php
@@ -10,7 +10,7 @@
     </div>
     <div class="form-group">
         <label for="password"><?= lang('Password', 'Passwort') ?>: </label>
-        <input class="form-control" id="password" type="password" name="password" placeholder="your windows password" required />
+        <input class="form-control" id="password" type="password" name="password" placeholder="your password" required />
     </div>
 
     <input class="btn secondary" type="submit" name="submit" value="<?= lang("Log-in", 'Einloggen') ?>" />

--- a/pages/userlogin.php
+++ b/pages/userlogin.php
@@ -53,7 +53,7 @@ $UM = strtoupper(USER_MANAGEMENT);
         </div>
         <div class="form-group">
             <label for="password"><?= lang('Password', 'Passwort') ?>: </label>
-            <input class="form-control" id="password" type="password" name="password" placeholder="your windows password" required />
+            <input class="form-control" id="password" type="password" name="password" placeholder="your password" required />
         </div>
         <input class="btn secondary" type="submit" name="submit" value="<?= lang("Log-in", 'Einloggen') ?>" />
     </form>
@@ -88,7 +88,7 @@ $UM = strtoupper(USER_MANAGEMENT);
         </div>
         <div class="form-group">
             <label for="password"><?= lang('Password', 'Passwort') ?>: </label>
-            <input class="form-control" id="password" type="password" name="password" placeholder="your windows password" required />
+            <input class="form-control" id="password" type="password" name="password" placeholder="your password" required />
         </div>
         <input class="btn secondary" type="submit" name="submit" value="<?= lang("Log-in", 'Einloggen') ?>" />
 


### PR DESCRIPTION
As seen in the screenshot below, the word "windows" can mislead users to type or reuse their Windows account password.

<img width="928" height="415" alt="screenshot_2025-10-08_09-47-46_409311533" src="https://github.com/user-attachments/assets/3104c4fd-d78a-45e4-9179-c62c1e3369af" />
