### PR TITLE
Add XOR (exclusive OR) field functionality for admin forms

### DIFF
--- a/routes/activities.php
+++ b/routes/activities.php
@@ -468,6 +468,18 @@ Route::post('/crud/activities/create', function () {
 
     $values = validateValues($_POST['values'], $DB);
 
+    // Validate XOR groups
+    $typeSchema = $osiris->adminTypes->findOne(['id' => $activityType]);
+    if ($typeSchema && isset($typeSchema['fields'])) {
+        $schema = ['items' => DB::doc2Arr($typeSchema['fields'])];
+        try {
+            validateXorGroups($values, $schema, $DB);
+        } catch (Exception $e) {
+            printMsg($e->getMessage(), 'error');
+            die();
+        }
+    }
+
     // add information on creating process
     $values['created'] = date('Y-m-d');
     $values['created_by'] = ($_SESSION['username']);
@@ -698,6 +710,21 @@ Route::post('/crud/activities/update/([A-Za-z0-9]*)', function ($id) {
     if (!isset($_POST['values'])) die("no values given");
     $collection = $osiris->activities;
     $values = validateValues($_POST['values'], $DB);
+
+    // Validate XOR groups
+    if (isset($_POST['values']['type'])) {
+        $activityType = $_POST['values']['type'];
+        $typeSchema = $osiris->adminTypes->findOne(['id' => $activityType]);
+        if ($typeSchema && isset($typeSchema['fields'])) {
+            $schema = ['items' => DB::doc2Arr($typeSchema['fields'])];
+            try {
+                validateXorGroups($values, $schema, $DB);
+            } catch (Exception $e) {
+                printMsg($e->getMessage(), 'error');
+                die();
+            }
+        }
+    }
 
     if (isset($_POST['minor']) && $_POST['minor'] == 1) {
         unset($values['authors']);


### PR DESCRIPTION
Implements mutual exclusivity for form fields, allowing admins to specify that only one field from a group must be filled (e.g., either select from dropdown OR enter text manually, but not both).

Features:
- Form Builder UI: Added XOR group input in properties panel with bilingual labels and tooltips explaining the functionality
- Visual Indicators: Fields in XOR groups show colored left border and badge icon in form builder canvas for easy identification
- Client-Side Validation: JavaScript automatically disables other fields in group when one is filled, with form submission validation
- Server-Side Validation: PHP validation ensures exactly one field per XOR group is filled, preventing data inconsistencies
- Data Attributes: XOR group names stored in field props and rendered as data-xor-group attributes on form fields

Changes:
- pages/admin/form-builder.php: Added XOR group configuration UI, badge rendering, JavaScript handlers for highlighting and validation
- php/Modules.php: Added data-xor-group attributes to field rendering in print_module() and custom_field(), includes XOR validation script
- php/_config.php: New validateXorGroups() function for server-side validation
- routes/activities.php: Integrated XOR validation in create/update routes

Example Use Case: Conference articles can now require either selecting an existing event from dropdown OR typing event name manually, ensuring exactly one option.