### PR TITLE
Fix: Dockerfiles and docker-compose files

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,7 +5,7 @@ FROM php:8.1-cli AS composer
 RUN apt-get update && apt-get install -y git unzip
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Set workdir
 WORKDIR /app

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,7 @@ services:
     container_name: osiris
     volumes:
       - .:/var/www/html
+      - vendor-data-dev:/var/www/html/vendor
       - ./img:/var/www/html/img:rw
 
     ports:
@@ -31,3 +32,4 @@ services:
 
 volumes:
   mongo-data-dev:
+  vendor-data-dev:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,7 @@ services:
       - 8080:80
     volumes:
       - .:/var/www/html/
+      - vendor-data:/var/www/html/vendor
       - ./img:/var/www/html/img:rw
 
   app:
@@ -19,6 +20,7 @@ services:
       - 9000
     volumes:
       - .:/var/www/html/
+      - vendor-data:/var/www/html/vendor
     environment:
       - COMPOSER_ALLOW_SUPERUSER=1
       - OSIRIS_DB_HOST=mongo
@@ -35,3 +37,4 @@ services:
 
 volumes:
   mongo-data:
+  vendor-data:

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -5,7 +5,7 @@ FROM php:8.1-fpm-alpine AS composer
 RUN apk add --no-cache git unzip
 
 # Install Composer
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Set workdir
 WORKDIR /app


### PR DESCRIPTION
Hi,
this is supposed to fix #487 and #500 so that a podman build of the Dockerfiles does not fail because of the stale build-stage reference and that the run of the compose files does not overwrite the vendor folders.
Thank you!