### PR TITLE
fix: correct Forschund to Forschung in Project.php

### DIFF
--- a/php/Project.php
+++ b/php/Project.php
@@ -592,7 +592,7 @@ class Project extends Vocabulary
     public function getCountryRole($role)
     {
         $country_roles = [
-            'in' => lang('Research in', 'Forschund in'),
+            'in' => lang('Research in', 'Forschung in'),
             'about' => lang('Research about', 'Forschung über'),
             'both' => lang('Research in and about', 'Forschung in und über')
         ];


### PR DESCRIPTION
## Summary
Fix typo in German UI text: `Forschund` → `Forschung` in php/Project.php:595

The German phrase for "Research in" was misspelled as "Forschund" instead of the correct "Forschung".

## Change
- php/Project.php line 595: `'in' => lang('Research in', 'Forschund in')` → `'in' => lang('Research in', 'Forschung in')`

## Fixes
- Closes #512