### PR TITLE
fix #545 by marking activities with affiliated editors as affiliated

### DIFF
--- a/routes/api/portfolio.php
+++ b/routes/api/portfolio.php
@@ -1262,6 +1262,10 @@ Route::get('/portfolio/activity/([^/]*)', function ($id) {
         ];
     }
 
+    foreach ($doc['editors'] as $e){
+        if ($e['aoi']) $result['affiliated'] =  true;
+    }
+
     $depts = [];
     if (!empty($doc['units'])) {
         foreach ($doc['units'] as $d) {


### PR DESCRIPTION
Fixing #545 by marking an activity as affiliated in the portfolio activity route, if any editor of the activity is affiliated