### PR TITLE
fix #551, let renderAuthorUnits run everytime onactivity/create route

### DIFF
--- a/routes/activities.php
+++ b/routes/activities.php
@@ -706,9 +706,7 @@ Route::post('/crud/activities/create', function () {
         $values['projects'] = $projects;
     }
 
-    if (isset($values['authors'])) {
-        $values = renderAuthorUnits($values);
-    }
+    $values = renderAuthorUnits($values);
 
     // if this activity is created from a draft, delete the draft
     if (isset($values['draft_id']) && !empty($values['draft_id'])) {


### PR DESCRIPTION
fixing bug #551 by calling function `renderAuthorUnits` every time an activity is created, before it was only called if `authors` existed