### PR TITLE
Add dev contact button

### DIFF
--- a/js/user-editor.js
+++ b/js/user-editor.js
@@ -448,6 +448,7 @@ function validateContact(element) {
 
     if (contactValue === '') {
         $(element).toggleClass('is-invalid', true);
+        $(element).toggleClass('is-valid', false);
         return [true, ''];
     }
     
@@ -455,23 +456,34 @@ function validateContact(element) {
     if (contactType === 'mail' || contactType === 'teams') {
         if (!emailPattern.test(contactValue)) {
             $(element).toggleClass('is-invalid', true);
+            $(element).toggleClass('is-valid', false);
             return [false, lang('Please enter a valid email address.', 'Bitte geben Sie eine gültige E-Mail-Adresse ein.')];
         }
     } else if (contactType === 'slack') {
         const slackPattern = /^[a-zA-Z0-9._-]+$/;
         if (!slackPattern.test(contactValue)) {
             $(element).toggleClass('is-invalid', true);
+            $(element).toggleClass('is-valid', false);
             return [false, lang('Please enter a valid Slack username.', 'Bitte geben Sie einen gültigen Slack-Benutzernamen ein.')];
         }
     } else if (contactType === 'matrix') {
         const matrixPattern = /^@.+:.+$/;
         if (!matrixPattern.test(contactValue)) {
             $(element).toggleClass('is-invalid', true);
+            $(element).toggleClass('is-valid', false);
             return [false, lang('Please enter a valid Matrix ID.', 'Bitte geben Sie eine gültige Matrix-ID ein.')];
         }
-    } 
+    } else if (contactType === 'other') {
+        const urlPattern = /^(https?:\/\/)?([\w-]+(\.[\w-]+)+)(\/[\w-]*)*\/?$/;
+        if (!urlPattern.test(contactValue)) {
+            $(element).toggleClass('is-invalid', true);
+            $(element).toggleClass('is-valid', false);
+            return [false, lang('Please enter a valid URL.', 'Bitte geben Sie eine gültige URL ein.')];
+        }
+    }
 
     $(element).toggleClass('is-invalid', false);
+    $(element).toggleClass('is-valid', true);
     return [true, ''];
 }
 

--- a/js/user-editor.js
+++ b/js/user-editor.js
@@ -474,7 +474,7 @@ function validateContact(element) {
             return [false, lang('Please enter a valid Matrix ID.', 'Bitte geben Sie eine gültige Matrix-ID ein.')];
         }
     } else if (contactType === 'other') {
-        const urlPattern = /^(https?:\/\/)?([\w-]+(\.[\w-]+)+)(\/[\w-]*)*\/?$/;
+        const urlPattern = /^(https?:\/\/)([\w-]+(\.[\w-]+)+)(\/[\w-]*)*\/?$/;
         if (!urlPattern.test(contactValue)) {
             $(element).toggleClass('is-invalid', true);
             $(element).toggleClass('is-valid', false);

--- a/js/user-editor.js
+++ b/js/user-editor.js
@@ -442,6 +442,39 @@ function validateSocial(element){
     return [true, msg];
 }
 
+function validateContact(element) {
+    const contactType = $('#contact-button-type').val();
+    const contactValue = $(element).val().trim();
+
+    if (contactValue === '') {
+        $(element).toggleClass('is-invalid', true);
+        return [true, ''];
+    }
+    
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (contactType === 'mail' || contactType === 'teams') {
+        if (!emailPattern.test(contactValue)) {
+            $(element).toggleClass('is-invalid', true);
+            return [false, lang('Please enter a valid email address.', 'Bitte geben Sie eine gültige E-Mail-Adresse ein.')];
+        }
+    } else if (contactType === 'slack') {
+        const slackPattern = /^[a-zA-Z0-9._-]+$/;
+        if (!slackPattern.test(contactValue)) {
+            $(element).toggleClass('is-invalid', true);
+            return [false, lang('Please enter a valid Slack username.', 'Bitte geben Sie einen gültigen Slack-Benutzernamen ein.')];
+        }
+    } else if (contactType === 'matrix') {
+        const matrixPattern = /^@.+:.+$/;
+        if (!matrixPattern.test(contactValue)) {
+            $(element).toggleClass('is-invalid', true);
+            return [false, lang('Please enter a valid Matrix ID.', 'Bitte geben Sie eine gültige Matrix-ID ein.')];
+        }
+    } 
+
+    $(element).toggleClass('is-invalid', false);
+    return [true, ''];
+}
+
 function cleanEmptySocials() {
     $('#socials input').each(function() {
         const url = String($(this).val() || '').trim();
@@ -477,7 +510,8 @@ const validators = {
     password: validatePassword,
     password2: validatePassword2,
     email: validateEmail,
-    telephone: validateTelephone
+    telephone: validateTelephone,
+    contact: validateContact
 }
 
 

--- a/news.md
+++ b/news.md
@@ -1,3 +1,16 @@
+<time datetime="2026-08-18">18.08.2026</time>
+<a class="anchor" href="#version-2.1.1" id="version-2.1.1"></a>
+
+## Version 2.1.1
+
+Im letzten Release hat unser Git leider zwei kleine Fehler eingebaut, die wir mit diesem Patch behoben haben:
+
+1. Die neue News-Seite zeigte verknüpfte Informationen sehr rudimentär an (Hier ist uns ein ganzer Commit abhanden gekommen).
+2. Auf der Journal-Bearbeiten-Seite fehlte nach dem Merge einfach eine Zeile, wodurch die ganze Seite nicht mehr geladen wurde.
+
+Beide Probleme sind nun behoben. Für die Unannehmlichkeiten möchten wir uns entschuldigen und danken allen, die uns auf die Probleme hingewiesen haben.
+
+
 <time datetime="2026-08-14">14.08.2026</time>
 <a class="anchor" href="#version-2.1.0" id="version-2.1.0"></a>
 

--- a/pages/admin/persons.php
+++ b/pages/admin/persons.php
@@ -118,7 +118,7 @@ $persons = $osiris->adminPersons->find();
                     <?php
                     $db_pictures = $Settings->featureEnabled('db_pictures');
                     ?>
-                    <div class=" custom-radio d-inline-block ml-10">>
+                    <div class="custom-radio d-inline-block ml-10">
                         <input type="radio" id="db_pictures-true" value="1" name="features[db_pictures]" <?= $db_pictures ? 'checked' : '' ?>>
                         <label for="db_pictures-true"><?= lang('Save in database', 'In Datenbank speichern') ?></label>
                     </div>
@@ -141,19 +141,64 @@ $persons = $osiris->adminPersons->find();
                         <?= lang('Contact button in user profiles', 'Kontakt-Button in Benutzerprofilen') ?>
                     </label>
                     <?php
-                    $achievements = $Settings->featureEnabled('contact-button');
+                    $contactButton = $Settings->featureEnabled('contact-button');
                     ?>
-
                     <div class="custom-radio d-inline-block ml-10">
-                        <input type="radio" id="contact-button-true" value="1" name="features[contact-button]" <?= $achievements ? 'checked' : '' ?>>
+                        <input type="radio" id="contact-button-true" value="1" name="features[contact-button]" <?= $contactButton ? 'checked' : '' ?>>
                         <label for="contact-button-true"><?= lang('enabled', 'aktiviert') ?></label>
                     </div>
-
                     <div class="custom-radio d-inline-block ml-10">
-                        <input type="radio" id="contact-button-false" value="0" name="features[contact-button]" <?= $achievements ? '' : 'checked' ?>>
+                        <input type="radio" id="contact-button-false" value="0" name="features[contact-button]" <?= $contactButton ? '' : 'checked' ?>>
                         <label for="contact-button-false"><?= lang('disabled', 'deaktiviert') ?></label>
                     </div>
+                    <small class="d-block text-muted">
+                        <?= lang('If this function is activated, a contact button will be displayed in the user profiles. The contact button can be configured individually for each user.', 'Wenn diese Funktion aktiviert ist, wird in den Benutzerprofilen ein Kontakt-Button angezeigt. Der Kontakt-Button kann für jeden Nutzer individuell konfiguriert werden.') ?>
+                    </small>
+                </div>
+                <script>
+                    $(document).ready(function() {
+                        if ($('#contact-button-true').is(':checked')) {
+                            $('#contact-button-allowed').show();
+                        } else {
+                            $('#contact-button-allowed').hide();
+                        }
 
+                        $('#contact-button-true').on('change', function() {
+                            $('#contact-button-allowed').show();
+                        });
+                        $('#contact-button-false').on('change', function() {
+                            $('#contact-button-allowed').hide();
+                        });
+                    });
+                </script>
+                <?php
+                $standardContactTypes = ['mail' => "0", 'slack' => "0", 'teams' => "0", 'matrix' => "0", 'other' => "0"];
+                $contactSettings = $Settings->get('contact-button')->getArrayCopy();
+                $contactTypes = array_merge($standardContactTypes, $contactSettings ?? []);
+                ?>
+                <div class="form-group" style="display: none;" id="contact-button-allowed">
+                    <table class="table simple w-full small mb-10">
+                        <thead>
+                            <tr>
+                                <th><?= lang('Active', 'Aktiv') ?></th>
+                                <th><?= lang('Contact type', 'Kontakt-Typ') ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php
+                            foreach ($contactTypes as $type => $enabled) {
+                            ?>
+                                <tr>
+                                    <td>
+                                        <input type="checkbox" name="general[contact-button][<?= $type ?>]" id="contact-button-<?= $type ?>" value="1" <?= $enabled ? 'checked' : '' ?>>
+                                    </td>
+                                    <td>
+                                        <?= lang(ucfirst($type), ucfirst($type)) ?>
+                                    </td>
+                                </tr>
+                            <?php } ?>
+                        </tbody>
+                    </table>
                 </div>
 
                 

--- a/pages/admin/persons.php
+++ b/pages/admin/persons.php
@@ -136,6 +136,28 @@ $persons = $osiris->adminPersons->find();
                     </small>
                 </div>
 
+                <div class="form-group">
+                    <label for="" class="font-weight-bold">
+                        <?= lang('Contact button in user profiles', 'Kontakt-Button in Benutzerprofilen') ?>
+                    </label>
+                    <?php
+                    $achievements = $Settings->featureEnabled('contact-button');
+                    ?>
+
+                    <div class="custom-radio d-inline-block ml-10">
+                        <input type="radio" id="contact-button-true" value="1" name="features[contact-button]" <?= $achievements ? 'checked' : '' ?>>
+                        <label for="contact-button-true"><?= lang('enabled', 'aktiviert') ?></label>
+                    </div>
+
+                    <div class="custom-radio d-inline-block ml-10">
+                        <input type="radio" id="contact-button-false" value="0" name="features[contact-button]" <?= $achievements ? '' : 'checked' ?>>
+                        <label for="contact-button-false"><?= lang('disabled', 'deaktiviert') ?></label>
+                    </div>
+
+                </div>
+
+                
+
 
                 <?php if (strtoupper(USER_MANAGEMENT) !== 'AUTH') { ?>
                     <div class="form-group">

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -571,16 +571,29 @@ if ($currentuser || $Settings->hasPermission('user.image')) { ?>
             </div>
         <?php } ?>
 
-                <!--- Contact Button --->
+        <!--- Contact Button --->
         <?php
-        if ($Settings->featureEnabled('contact-button') && ($scientist['contact_button'] ?? true)) {
+        if ($Settings->featureEnabled('contact-button') && ($scientist['contact-button'] ?? false)) {
             $contact = $scientist['contact'] ?? null;
+            $contactType = $scientist['contact-button-type'] ?? 'mail';
+            $contactURL = null;
             if (!isset($contact) && isset($scientist['mail'])){
-                $contact = "mailto:" . $scientist['mail'];
+                $contactURL = "mailto:" . $scientist['mail'];
             }
-            if($contact) { ?>
+            if($contact) { 
+                if ($contactType == 'mail') {
+                    $contactURL = "mailto:" . $contact;
+                } elseif ($contactType == 'teams') {
+                    $contactURL = "https://teams.microsoft.com/l/chat/0/0?users=" . $contact;
+                } elseif ($contactType == 'slack') {
+                    $contactURL = "https://slack.com/app_redirect?channel=" . $contact;
+                } elseif ($contactType == 'matrix') {
+                    $contactURL = "https://matrix.to/#/" . $contact;
+                } elseif ($contactType == 'other') {
+                    $contactURL = $contact;
+                }?>
                 <div class="btn-group btn-group-lg" >
-                    <a class="btn secondary outline" href="<?= $contact ?>" data-toggle="tooltip" data-title="<?= lang('Contact ', 'Kontaktiere ') . $scientist['first'] ?>">
+                    <a class="btn secondary outline" href="<?= $contactURL ?>" target="_blank" data-toggle="tooltip" data-title="<?= lang('Contact ', 'Kontaktiere ') . $scientist['first'] ?>">
                         <?= lang('Contact', 'Kontakt')?>
                     </a>
                 </div>

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -591,9 +591,18 @@ if ($currentuser || $Settings->hasPermission('user.image')) { ?>
                     $contactURL = "https://matrix.to/#/" . $contact;
                 } elseif ($contactType == 'other') {
                     $contactURL = $contact;
-                }?>
+                }
+                $contactLogo = socialLogo($contactType);
+                if ($contactType == 'other') {
+                    $contactInfo = lang('prefered contact link', 'bevorzugtem Kontakt-Link');
+                }
+                else {
+                    $contactInfo = ucfirst($contactType);
+                }
+                ?>
                 <div class="btn-group btn-group-lg" >
-                    <a class="btn secondary outline" href="<?= $contactURL ?>" target="_blank" data-toggle="tooltip" data-title="<?= lang('Contact ', 'Kontaktiere ') . $scientist['first'] ?>">
+                    <a class="btn secondary outline" href="<?= $contactURL ?>" target="_blank" data-toggle="tooltip" data-title="<?= lang('Contact ', 'Kontaktiere ') . $scientist['first'] . lang(' via ', ' per ') . $contactInfo ?>">
+                        <i class="ph <?= $contactLogo ?>"></i>
                         <?= lang('Contact', 'Kontakt')?>
                     </a>
                 </div>

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -479,10 +479,7 @@ if ($currentuser || $Settings->hasPermission('user.image')) { ?>
                 <?php } ?>
             </div>
         <?php } ?>
-
     </div>
-
-
 
 
     <?php
@@ -574,7 +571,21 @@ if ($currentuser || $Settings->hasPermission('user.image')) { ?>
             </div>
         <?php } ?>
 
-
+                <!--- Contact Button --->
+        <?php
+        if ($Settings->featureEnabled('contact-button') && ($scientist['contact_button'] ?? true)) {
+            $contact = $scientist['contact'] ?? null;
+            if (!isset($contact) && isset($scientist['mail'])){
+                $contact = "mailto:" . $scientist['mail'];
+            }
+            if($contact) { ?>
+                <div class="btn-group btn-group-lg" >
+                    <a class="btn secondary outline" href="<?= $contact ?>" data-toggle="tooltip" data-title="<?= lang('Contact ', 'Kontaktiere ') . $scientist['first'] ?>">
+                        <?= lang('Contact', 'Kontakt')?>
+                    </a>
+                </div>
+            <?php } ?>
+        <?php } ?>
     </div>
 
 <?php } ?>

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -575,12 +575,13 @@ if ($currentuser || $Settings->hasPermission('user.image')) { ?>
         <?php
         if ($Settings->featureEnabled('contact-button') && ($scientist['contact-button'] ?? false)) {
             $contact = $scientist['contact'] ?? null;
-            $contactType = $scientist['contact-button-type'] ?? 'mail';
-            $contactURL = null;
-            if (!isset($contact) && isset($scientist['mail'])){
-                $contactURL = "mailto:" . $scientist['mail'];
+            $contactType = $scientist['contact-button-type'] ?? null;
+            $contactTypeSettings = $Settings->get('contact-button')->getArrayCopy();
+            if (!isset($contactTypeSettings[$contactType]) || !($contactTypeSettings[$contactType] === '1')) {
+                $contactType = null;
             }
-            if($contact) { 
+            $contactURL = null;
+            if($contact && $contactType) { 
                 if ($contactType == 'mail') {
                     $contactURL = "mailto:" . $contact;
                 } elseif ($contactType == 'teams') {

--- a/pages/user-editor.php
+++ b/pages/user-editor.php
@@ -716,7 +716,7 @@ $active = function ($field) use ($data_fields) {
                 <div class="form-row row-eq-spacing" style="display: none;" id="contact-button-settings">
                     <div class="col-sm">
                         <label for="contact-button-type"><?= lang('Contact type', 'Kontakt-Typ') ?></label>
-                        <select id="contact-button-type" name="values[contact-button-type]" class="form-control">
+                        <select id="contact-button-type" name="values[contact-button-type]" class="form-control" onchange="toggleContact(this)">
                             <?php foreach (['mail', 'slack', 'teams', 'matrix', 'other'] as $type) { ?>
                                 <option value="<?= $type ?>" <?= $contact_button_type == $type ? 'selected' : '' ?>><?= ucfirst($type) ?></option>
                             <?php } ?>
@@ -724,7 +724,7 @@ $active = function ($field) use ($data_fields) {
                     </div>
                     <div class="col-sm">
                         <label for="contact"><?= lang('Contact', 'Kontakt') ?></label>
-                        <input type="text" name="values[contact]" id="contact" class="form-control need-validation" data-validator="contact"  value="<?= $data['contact'] ?? '' ?>" onblur="validateContact(this)">
+                        <input type="text" name="values[contact]" id="contact-button-extra" class="form-control need-validation" data-validator="contact"  value="<?= $data['contact'] ?? '' ?>" oninput="validateContact(this)">
                     </div>
                 </div>
                 <script>
@@ -732,6 +732,7 @@ $active = function ($field) use ($data_fields) {
                         function toggleContactButtonSettings() {
                             if ($('#contact-button-true').is(':checked')) {
                                 $('#contact-button-settings').show();
+                                toggleContact($('#contact-button-type'));
                             } else {
                                 $('#contact-button-settings').hide();
                             }
@@ -739,6 +740,49 @@ $active = function ($field) use ($data_fields) {
                         toggleContactButtonSettings();
                         $('input[name="values[contact-button]"]').change(toggleContactButtonSettings);
                     });
+
+                    function toggleContact(select) {
+                        var type = $(select).val();
+                        var contactInput = $('#contact-button-extra');
+                        if (type === 'mail' || type === 'teams') {
+                            contactInput.attr('placeholder', '<?= lang('Enter email address', 'E-Mail-Adresse eingeben') ?>');
+                            if (('<?= $data['contact-button-type'] ?? false ?>' === 'mail' || '<?= $data['contact-button-type'] ?? false ?>' === 'teams' ) && '<?= $data['contact'] ?? false ?>') {
+                                contactInput.val('<?= $data['contact'] ?? '' ?>');
+                            } else if ('<?= $data['mail'] ?? false ?>') {
+                                contactInput.val('<?= $data['mail'] ?>');
+                            } else {
+                                contactInput.val('');
+                            }
+                        } else if (type === 'slack') {
+                            contactInput.attr('placeholder', '<?= lang('Enter Slack user id', 'Slack-Nutzer-ID eingeben') ?>');
+                            if ('<?= $data['contact-button-type'] ?? false ?>' === 'slack' && '<?= $data['contact'] ?? false ?>') {
+                                contactInput.val('<?= $data['contact'] ?? '' ?>');
+                            } else {
+                                contactInput.val('');
+                            }
+                        } else if (type === 'matrix') {
+                            contactInput.attr('placeholder', '<?= lang('Enter Matrix ID', 'Matrix-ID eingeben') ?>');
+                            if ('<?= $data['contact-button-type'] ?? false ?>' === 'matrix' && '<?= $data['contact'] ?? false ?>') {
+                                contactInput.val('<?= $data['contact'] ?? '' ?>');
+                            } else if ('<?= $data['socials']['matrix'] ?? false ?>') {
+                                matrix = '<?= $data['socials']['matrix'] ?? '' ?>';
+                                matrix = '<?= $data['socials']['matrix'] ?? '' ?>';
+                                matrixId = matrix.includes('/#/') ? matrix.split('/#/')[1] : matrix;
+                                contactInput.val(matrixId);
+                            } else {
+                                contactInput.val('');
+                            }
+                        } else if (type === 'other') {
+                            contactInput.attr('placeholder', '<?= lang('Enter contact URL', 'Kontakt-URL eingeben') ?>');
+                            if ('<?= $data['contact-button-type'] ?? false ?>' === 'other' && '<?= $data['contact'] ?? false ?>') {
+                                contactInput.val('<?= $data['contact'] ?? '' ?>');
+                            } else {
+                                contactInput.val('');
+                            }
+                        }
+                        validateContact(contactInput);
+                    }
+
                 </script>
             </div>
         <?php } ?>

--- a/pages/user-editor.php
+++ b/pages/user-editor.php
@@ -704,15 +704,19 @@ $active = function ($field) use ($data_fields) {
             <?php $contact_button = $data['contact-button'] ?? false; ?>
             <?php $contact_button_type = $data['contact-button-type'] ?? 'mail'; ?>
             <div class="form-group">
-                <div class="custom-radio d-inline-block ml-10">
-                    <input type="radio" id="contact-button-true" value="1" name="values[contact-button]" <?= $contact_button ? 'checked' : '' ?>>
-                    <label for="contact-button-true"><?= lang('enabled', 'aktiviert') ?></label>
+                <div>
+                    <div class="custom-radio d-inline-block ml-10">
+                        <input type="radio" id="contact-button-true" value="1" name="values[contact-button]" <?= $contact_button ? 'checked' : '' ?>>
+                        <label for="contact-button-true"><?= lang('enabled', 'aktiviert') ?></label>
+                    </div>
+                    <div class="custom-radio d-inline-block ml-10">
+                        <input type="radio" id="contact-button-false" value="0" name="values[contact-button]" <?= $contact_button ? '' : 'checked' ?>>
+                        <label for="contact-button-false"><?= lang('disabled', 'deaktiviert') ?></label>
+                    </div>
                 </div>
-
-                <div class="custom-radio d-inline-block ml-10">
-                    <input type="radio" id="contact-button-false" value="0" name="values[contact-button]" <?= $contact_button ? '' : 'checked' ?>>
-                    <label for="contact-button-false"><?= lang('disabled', 'deaktiviert') ?></label>
-                </div>
+                <small class="text-muted">
+                    <?= lang('The contact button will be displayed on your OSIRIS profile page. You can choose your preferred contact type to be displayed.', 'Der Kontakt-Button wird auf deiner OSIRIS-Profilseite angezeigt. Du kannst deinen Wunsch-Kontaktweg wählen.') ?>
+                </small>
                 <div class="form-row row-eq-spacing" style="display: none;" id="contact-button-settings">
                     <div class="col-sm">
                         <label for="contact-button-type"><?= lang('Contact type', 'Kontakt-Typ') ?></label>
@@ -724,7 +728,8 @@ $active = function ($field) use ($data_fields) {
                     </div>
                     <div class="col-sm">
                         <label for="contact"><?= lang('Contact', 'Kontakt') ?></label>
-                        <input type="text" name="values[contact]" id="contact-button-extra" class="form-control need-validation" data-validator="contact"  value="<?= $data['contact'] ?? '' ?>" oninput="validateContact(this)">
+                        <input type="text" name="values[contact]" id="contact-button-input" class="form-control need-validation" data-validator="contact"  value="<?= $data['contact'] ?? '' ?>" oninput="validateContact(this)">
+                        <small class="text-muted" id="contact-button-input-help"></small>
                     </div>
                 </div>
                 <script>
@@ -743,9 +748,11 @@ $active = function ($field) use ($data_fields) {
 
                     function toggleContact(select) {
                         var type = $(select).val();
-                        var contactInput = $('#contact-button-extra');
+                        var contactInput = $('#contact-button-input');
+                        var contactHelp = $('#contact-button-input-help');
                         if (type === 'mail' || type === 'teams') {
                             contactInput.attr('placeholder', '<?= lang('Enter email address', 'E-Mail-Adresse eingeben') ?>');
+                            contactHelp.text('<?= lang('Please add an email address. It will be used for the contact button.', 'Bitte hier eine E-Mail-Adresse eingeben. Sie wird für den Kontakt-Button verwendet.') ?>');
                             if (('<?= $data['contact-button-type'] ?? false ?>' === 'mail' || '<?= $data['contact-button-type'] ?? false ?>' === 'teams' ) && '<?= $data['contact'] ?? false ?>') {
                                 contactInput.val('<?= $data['contact'] ?? '' ?>');
                             } else if ('<?= $data['mail'] ?? false ?>') {
@@ -755,6 +762,7 @@ $active = function ($field) use ($data_fields) {
                             }
                         } else if (type === 'slack') {
                             contactInput.attr('placeholder', '<?= lang('Enter Slack user id', 'Slack-Nutzer-ID eingeben') ?>');
+                            contactHelp.text('<?= lang('Please add a Slack user id in the format U12345678. It will be used for the contact button.', 'Bitte hier eine Slack-Nutzer-ID im Format U12345678 eingeben. Sie wird für den Kontakt-Button verwendet.') ?>');
                             if ('<?= $data['contact-button-type'] ?? false ?>' === 'slack' && '<?= $data['contact'] ?? false ?>') {
                                 contactInput.val('<?= $data['contact'] ?? '' ?>');
                             } else {
@@ -762,6 +770,7 @@ $active = function ($field) use ($data_fields) {
                             }
                         } else if (type === 'matrix') {
                             contactInput.attr('placeholder', '<?= lang('Enter Matrix ID', 'Matrix-ID eingeben') ?>');
+                            contactHelp.text('<?= lang('Please add a Matrix ID. It will be used for the contact button.', 'Bitte hier eine Matrix-ID eingeben. Sie wird für den Kontakt-Button verwendet.') ?>');
                             if ('<?= $data['contact-button-type'] ?? false ?>' === 'matrix' && '<?= $data['contact'] ?? false ?>') {
                                 contactInput.val('<?= $data['contact'] ?? '' ?>');
                             } else if ('<?= $data['socials']['matrix'] ?? false ?>') {
@@ -774,6 +783,7 @@ $active = function ($field) use ($data_fields) {
                             }
                         } else if (type === 'other') {
                             contactInput.attr('placeholder', '<?= lang('Enter contact URL', 'Kontakt-URL eingeben') ?>');
+                            contactHelp.text('<?= lang('Please add a contact URL. It will be used for the contact button.', 'Bitte hier eine Kontakt-URL eingeben. Sie wird für den Kontakt-Button verwendet.') ?>');
                             if ('<?= $data['contact-button-type'] ?? false ?>' === 'other' && '<?= $data['contact'] ?? false ?>') {
                                 contactInput.val('<?= $data['contact'] ?? '' ?>');
                             } else {

--- a/pages/user-editor.php
+++ b/pages/user-editor.php
@@ -766,7 +766,7 @@ $active = function ($field) use ($data_fields) {
                             }
                         } else if (type === 'slack') {
                             contactInput.attr('placeholder', '<?= lang('Enter Slack user id', 'Slack-Nutzer-ID eingeben') ?>');
-                            contactHelp.text('<?= lang('Please add a Slack user id in the format U12345678. It will be used for the contact button.', 'Bitte hier eine Slack-Nutzer-ID im Format U12345678 eingeben. Sie wird für den Kontakt-Button verwendet.') ?>');
+                            contactHelp.text('<?= lang('Please add a Slack user id in the format U12345678. It will be used for the contact button. Keep in mind that the contact link will only work if the person clicking it is part of the same Slack Workspace', 'Bitte hier eine Slack-Nutzer-ID im Format U12345678 eingeben. Sie wird für den Kontakt-Button verwendet. Bitte beachte, dass der Link nur funktionieren wird, wenn die klickende Person Teil des gleichen Slack-Workspaces ist.') ?>');
                             if ('<?= $data['contact-button-type'] ?? false ?>' === 'slack' && '<?= $data['contact'] ?? false ?>') {
                                 contactInput.val('<?= $data['contact'] ?? '' ?>');
                             } else {
@@ -774,7 +774,7 @@ $active = function ($field) use ($data_fields) {
                             }
                         } else if (type === 'matrix') {
                             contactInput.attr('placeholder', '<?= lang('Enter Matrix ID', 'Matrix-ID eingeben') ?>');
-                            contactHelp.text('<?= lang('Please add a Matrix ID. It will be used for the contact button.', 'Bitte hier eine Matrix-ID eingeben. Sie wird für den Kontakt-Button verwendet.') ?>');
+                            contactHelp.text('<?= lang('Please add a Matrix ID in the format @username:server. It will be used for the contact button.', 'Bitte hier eine Matrix-ID im Format @username:server eingeben. Sie wird für den Kontakt-Button verwendet.') ?>');
                             if ('<?= $data['contact-button-type'] ?? false ?>' === 'matrix' && '<?= $data['contact'] ?? false ?>') {
                                 contactInput.val('<?= $data['contact'] ?? '' ?>');
                             } else if ('<?= $data['socials']['matrix'] ?? false ?>') {

--- a/pages/user-editor.php
+++ b/pages/user-editor.php
@@ -697,12 +697,15 @@ $active = function ($field) use ($data_fields) {
         <?php } ?>
 
         <!-- Contact Button -->
-        <?php if ($Settings->featureEnabled('contact-button')) { ?>
+        <?php if ($Settings->featureEnabled('contact-button') && !empty($Settings->get('contact-button'))) { ?>
             <h4>
                 <?= lang('Contact Button', 'Kontakt Button') ?>
             </h4>
-            <?php $contact_button = $data['contact-button'] ?? false; ?>
-            <?php $contact_button_type = $data['contact-button-type'] ?? 'mail'; ?>
+            <?php 
+                $contact_button = $data['contact-button'] ?? false;
+                $contact_button_type = $data['contact-button-type'] ?? 'mail';
+            ?>
+
             <div class="form-group">
                 <div>
                     <div class="custom-radio d-inline-block ml-10">
@@ -721,7 +724,8 @@ $active = function ($field) use ($data_fields) {
                     <div class="col-sm">
                         <label for="contact-button-type"><?= lang('Contact type', 'Kontakt-Typ') ?></label>
                         <select id="contact-button-type" name="values[contact-button-type]" class="form-control" onchange="toggleContact(this)">
-                            <?php foreach (['mail', 'slack', 'teams', 'matrix', 'other'] as $type) { ?>
+                            <?php foreach ($Settings->get('contact-button')->getArrayCopy() as $type => $enabled) { 
+                                if (!$enabled) continue; ?>
                                 <option value="<?= $type ?>" <?= $contact_button_type == $type ? 'selected' : '' ?>><?= ucfirst($type) ?></option>
                             <?php } ?>
                         </select>

--- a/pages/user-editor.php
+++ b/pages/user-editor.php
@@ -695,6 +695,54 @@ $active = function ($field) use ($data_fields) {
                 });
             </script>
         <?php } ?>
+
+        <!-- Contact Button -->
+        <?php if ($Settings->featureEnabled('contact-button')) { ?>
+            <h4>
+                <?= lang('Contact Button', 'Kontakt Button') ?>
+            </h4>
+            <?php $contact_button = $data['contact-button'] ?? false; ?>
+            <?php $contact_button_type = $data['contact-button-type'] ?? 'mail'; ?>
+            <div class="form-group">
+                <div class="custom-radio d-inline-block ml-10">
+                    <input type="radio" id="contact-button-true" value="1" name="values[contact-button]" <?= $contact_button ? 'checked' : '' ?>>
+                    <label for="contact-button-true"><?= lang('enabled', 'aktiviert') ?></label>
+                </div>
+
+                <div class="custom-radio d-inline-block ml-10">
+                    <input type="radio" id="contact-button-false" value="0" name="values[contact-button]" <?= $contact_button ? '' : 'checked' ?>>
+                    <label for="contact-button-false"><?= lang('disabled', 'deaktiviert') ?></label>
+                </div>
+                <div class="form-row row-eq-spacing" style="display: none;" id="contact-button-settings">
+                    <div class="col-sm">
+                        <label for="contact-button-type"><?= lang('Contact type', 'Kontakt-Typ') ?></label>
+                        <select id="contact-button-type" name="values[contact-button-type]" class="form-control">
+                            <?php foreach (['mail', 'slack', 'teams', 'matrix', 'other'] as $type) { ?>
+                                <option value="<?= $type ?>" <?= $contact_button_type == $type ? 'selected' : '' ?>><?= ucfirst($type) ?></option>
+                            <?php } ?>
+                        </select>
+                    </div>
+                    <div class="col-sm">
+                        <label for="contact"><?= lang('Contact', 'Kontakt') ?></label>
+                        <input type="text" name="values[contact]" id="contact" class="form-control need-validation" data-validator="contact"  value="<?= $data['contact'] ?? '' ?>" onblur="validateContact(this)">
+                    </div>
+                </div>
+                <script>
+                    $(document).ready(function() {
+                        function toggleContactButtonSettings() {
+                            if ($('#contact-button-true').is(':checked')) {
+                                $('#contact-button-settings').show();
+                            } else {
+                                $('#contact-button-settings').hide();
+                            }
+                        }
+                        toggleContactButtonSettings();
+                        $('input[name="values[contact-button]"]').change(toggleContactButtonSettings);
+                    });
+                </script>
+            </div>
+        <?php } ?>
+
     </section>
 
 

--- a/php/_config.php
+++ b/php/_config.php
@@ -983,6 +983,12 @@ function socialLogo($type)
             return 'ph-student';
         case 'email':
             return 'ph-email-logo';
+        case 'teams':
+            return 'ph-microsoft-teams-logo';
+        case 'slack':
+            return 'ph-slack-logo';
+        case 'mail':
+            return 'ph-envelope';
         default:
             return 'ph-link';
     }


### PR DESCRIPTION
Adding a user customizable contact button to the user profile page, including:

- Admin controls to turn contact button feature on and off
- Admin selector to choose which contact button channels are allowed
- User editor controls to turn on and off the contact button individually
- User editor selector for the preferred contact channel
- User editor contact link/mail input field, with auto suggestions for mail and matrix if already existing in user profile
- The contact button on the user profile page