### PR TITLE
Update mongodb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Open, simple and integrated research information system",
     "type": "project",
     "require": {
-        "mongodb/mongodb": "^1.12.0",
+        "mongodb/mongodb": "^2.4.1",
         "phpoffice/phpword": "dev-master",
         "renanbr/bibtex-parser": "^2.1",
         "phpmailer/phpmailer": "^6.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3e89fe331fe75d4606f48b9b8d1d826",
+    "content-hash": "b58fdf3c5d27aceb6901a42d3e6bd566",
     "packages": [
         {
             "name": "amenadiel/jpgraph",
@@ -622,23 +622,24 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.21.3",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "b8f569ec52542d2f1bfca88286f20d14a7f72536"
+                "url": "https://github.com/mongodb/mongo-php-library",
+                "reference": "1fbdc2ffff18a1ad6d92043b40060e4f546982ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/b8f569ec52542d2f1bfca88286f20d14a7f72536",
-                "reference": "b8f569ec52542d2f1bfca88286f20d14a7f72536",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/1fbdc2ffff18a1ad6d92043b40060e4f546982ff",
+                "reference": "1fbdc2ffff18a1ad6d92043b40060e4f546982ff",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0",
-                "ext-mongodb": "^1.21.0",
+                "ext-mongodb": "^2.4",
                 "php": "^8.1",
-                "psr/log": "^1.1.4|^2|^3"
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/polyfill-php85": "^1.33"
             },
             "replace": {
                 "mongodb/builder": "*"
@@ -646,9 +647,9 @@
             "require-dev": {
                 "doctrine/coding-standard": "^12.0",
                 "phpunit/phpunit": "^10.5.35",
-                "rector/rector": "^2.1.4",
+                "rector/rector": "~2.5.9",
                 "squizlabs/php_codesniffer": "^3.7",
-                "vimeo/psalm": "6.5.*"
+                "vimeo/psalm": "~6.14.2"
             },
             "type": "library",
             "extra": {
@@ -690,11 +691,7 @@
                 "mongodb",
                 "persistence"
             ],
-            "support": {
-                "issues": "https://github.com/mongodb/mongo-php-library/issues",
-                "source": "https://github.com/mongodb/mongo-php-library/tree/1.21.3"
-            },
-            "time": "2025-09-22T12:34:29+00:00"
+            "time": "2026-09-10T15:46:23+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -1408,6 +1405,86 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php85",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php85.git",
+                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/255fab485aaa1006ed411040c42aecd7b5302d7a",
+                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php85\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.5+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-01T12:47:55+00:00"
         }
     ],
     "packages-dev": [],
@@ -1418,10 +1495,10 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.1.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure ldap \
     && docker-php-ext-configure gd --with-jpeg --with-webp \
     && docker-php-ext-install ldap zip gd \
-    && pecl install mongodb-1.21.0 \
+    && pecl install mongodb-2.4.1 \
     && docker-php-ext-enable mongodb \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,7 +21,7 @@ services:
       sh -c "php -S 0.0.0.0:80 -t /var/www/html"
 
   mongo:
-    image: mongo:7.0
+    image: mongo:8.0
     container_name: mongodb_dev
     ports:
       - "27018:27017"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
       - OSIRIS_DB_HOST=mongo
 
   mongo:
-    image: mongo:7.0
+    image: mongo:8.0
     container_name: mongodb
     ports:
       - "27017:27017"

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -38,7 +38,7 @@ RUN apk update && apk add --no-cache \
     && docker-php-ext-configure ldap \
     && docker-php-ext-configure gd --with-jpeg --with-webp \
     && docker-php-ext-install ldap zip gd \
-    && pecl install mongodb-1.21.0 \
+    && pecl install mongodb-2.4.1 \
     && docker-php-ext-enable mongodb
 
 RUN printf "upload_max_filesize=16M\npost_max_size=18M\nmemory_limit=256M\n" > /usr/local/etc/php/conf.d/osiris-uploads.ini


### PR DESCRIPTION
Update MongoDB PHP library
Update composer lock
Update dockerfiles to use MongoDB 8.0 image

If switching to new MongoDB version: Make sure that the database feature compatibility version is high enough
Info for all Docker users: Delete vendor-data volume to make clean update
